### PR TITLE
Added ability to remove server after adding.

### DIFF
--- a/src/copas/copas.lua
+++ b/src/copas/copas.lua
@@ -444,6 +444,13 @@ function copas.addserver(server, handler, timeout)
         addTCPserver(server, handler, timeout)
     end
 end
+
+function copas.removeserver(server)
+  _servers[server] = nil
+  _reading:remove(server)
+  return server:close()
+end
+
 -------------------------------------------------------------------------------
 -- Adds an new courotine thread to Copas dispatcher
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Copas supports adding a new server, but no way to remove the added server. This patch adds this ability.

`:close` call is needed to allow the socket to be reused right away after removing the server.