### PR TITLE
fixed autoclose not closing udp sockets. added docs for autoclose

### DIFF
--- a/doc/us/reference.html
+++ b/doc/us/reference.html
@@ -84,6 +84,13 @@ are used to register servers and to execute the main loop of Copas:</p>
         registered handlers as long as it uses the Copas socket functions.
     </dd>
 
+    <dt><strong><code>copas.autoclose</code></strong></dt>
+    <dd>Constant that controls whether sockets are automatically closed.<br />
+        When a TCP handler function completes and terminates, then the client
+        socket will be automatically closed when <code>copas.autoclose</code> is 
+        truthy (neither <code>nil</code> nor <code>false</code>).
+    </dd>
+
     <dt><strong><code>copas.finished()</code></strong></dt>
     <dd>Checks whether anything remains to be done.<br />
         Returns <code>false</code> when the sockets lists for reading and writing


### PR DESCRIPTION
As with UDP sockets there are no client sockets, the client passed to the handler is the same as the server socket. So closing that socket upon the handler finishing, basically closes the server.

Fix will only close TCP sockets upon handler finishing.
