### PR TITLE
Support copas.sleep() in the main thread.

### DIFF
--- a/src/copas.lua
+++ b/src/copas.lua
@@ -693,8 +693,15 @@ local _sleeping_t = {
 
 -- yields the current coroutine and wakes it after 'sleeptime' seconds.
 -- If sleeptime<0 then it sleeps until explicitly woken up using 'wakeup'
+-- If not in a coroutine context, the main thread just sleeps for the
+-- given amount of time.
 function copas.sleep(sleeptime)
-    coroutine.yield((sleeptime or 0), _sleeping)
+    local co, ismain = coroutine.running()
+    if (not co) or ismain then
+        socket.sleep(sleeptime)
+    else
+        coroutine.yield((sleeptime or 0), _sleeping)
+    end
 end
 
 -- Wakes up a sleeping coroutine 'co'.


### PR DESCRIPTION
Useful when writing functions that work both in and out of a copas context.

Use case: I'm writing a REST client app that has a `register()` function that may need to sleep to retry. This function runs before my main event loop starts, but ocasionally the connection drops and I need to `register()` again, this time calling it within a copas context.
