### PR TITLE
Makefile: add DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 # $Id: Makefile,v 1.3 2007/10/29 22:50:16 carregal Exp $
 
+DESTDIR ?= 
+
 # Default prefix
-PREFIX = /usr/local
+PREFIX  ?= /usr/local
 
 # System's lua directory (where Lua libraries are installed)
-LUA_DIR= $(PREFIX)/share/lua/5.1
+LUA_DIR ?= $(PREFIX)/share/lua/5.1
 
 PKGPATH=-e "package.path='src/?.lua;'..package.path"
 
@@ -12,12 +14,12 @@ PKGPATH=-e "package.path='src/?.lua;'..package.path"
 LUA=lua
 
 install:
-	mkdir -p $(LUA_DIR)/copas
-	cp src/copas.lua $(LUA_DIR)/copas.lua
-	cp src/copas/ftp.lua $(LUA_DIR)/copas/ftp.lua
-	cp src/copas/smtp.lua $(LUA_DIR)/copas/smtp.lua
-	cp src/copas/http.lua $(LUA_DIR)/copas/http.lua
-	cp src/copas/limit.lua $(LUA_DIR)/copas/limit.lua
+	mkdir -p $(DESTDIR)$(LUA_DIR)/copas
+	cp src/copas.lua $(DESTDIR)$(LUA_DIR)/copas.lua
+	cp src/copas/ftp.lua $(DESTDIR)$(LUA_DIR)/copas/ftp.lua
+	cp src/copas/smtp.lua $(DESTDIR)$(LUA_DIR)/copas/smtp.lua
+	cp src/copas/http.lua $(DESTDIR)$(LUA_DIR)/copas/http.lua
+	cp src/copas/limit.lua $(DESTDIR)$(LUA_DIR)/copas/limit.lua
 
 test:
 	$(LUA) $(PKGPATH) tests/largetransfer.lua


### PR DESCRIPTION
Add a DESTDIR variable to the Makefile. This enables integration into
the Yocto-Project and harmonizes the Makefile with the one from
"coxpcall".

Signed-off-by: Richard Leitner <richard.leitner@skidata.com>