### PR TITLE
Fix issue #63

### DIFF
--- a/doc/us/index.html
+++ b/doc/us/index.html
@@ -114,6 +114,11 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
 <h2><a name="history"></a>History</h2>
 
 <dl class="history">
+    <dt><strong>Copas</strong> [unreleased]</dt>
+	<dd><ul>
+                <li>Fixed: coxpcall dependency in limit.lua #63 (Francois Perrad)</li>
+	</ul></dd>
+
     <dt><strong>Copas 2.0.2</strong> [2017]</dt>
 	<dd><ul>
 		<li>Added: <code>copas.running</code> flag</li>

--- a/src/copas/limit.lua
+++ b/src/copas/limit.lua
@@ -10,7 +10,7 @@ local pack = table.pack or function(...) return {n=select('#',...),...} end
 local unpack = function(t) return (table.unpack or unpack)(t, 1, t.n or #t) end
 
 local pcall = pcall
-if _VERSION=="Lua 5.1" then     -- obsolete: only for Lua 5.1 compatibility
+if _VERSION=="Lua 5.1" and not jit then     -- obsolete: only for Lua 5.1 compatibility
   pcall = require("coxpcall").pcall
 end
 


### PR DESCRIPTION
`coxpcall` is only required with PUC Lua 5.1, but not with LuaJIT

see issue #63 
