### PR TITLE
Adding copas.removethread() function to remove add threads

### DIFF
--- a/doc/us/reference.html
+++ b/doc/us/reference.html
@@ -113,6 +113,13 @@ are used to register servers and to execute the main loop of Copas:</p>
         removing the server. If <code>keep_open</code> is <code>true</code>, the socket
         is removed from the scheduler but it is not closed.
     </dd>
+	
+	<dt><strong><code>copas.removethread(thread)</code></strong></dt>
+    <dd>Removes a thread added to the Copas scheduler. 
+    	Takes a <code>thread</code> created by <code>copas.addthread()</code> and removes
+		it from the disptacher the next time it tries to resume. If <code>thread</code> isn't 
+		registered,	it does nothing.
+    </dd>
 
     <dt><strong><code>copas.running</code></strong></dt>
     <dd>A flag set to <code>true</code> when <code>copas.loop()</code> starts, and 

--- a/doc/us/reference.html
+++ b/doc/us/reference.html
@@ -106,19 +106,19 @@ are used to register servers and to execute the main loop of Copas:</p>
         and is passed to the <code>copas.step()</code> function.
         The loop returns when <code>copas.finished() == true</code>.
     </dd>
-    
+
     <dt><strong><code>copas.removeserver(skt [, keep_open])</code></strong></dt>
     <dd>Removes a server socket from the Copas scheduler. 
-    	By default, the socket will be closed to allow the socket to be reused right away after 
+        By default, the socket will be closed to allow the socket to be reused right away after 
         removing the server. If <code>keep_open</code> is <code>true</code>, the socket
         is removed from the scheduler but it is not closed.
     </dd>
-	
-	<dt><strong><code>copas.removethread(thread)</code></strong></dt>
-    <dd>Removes a thread added to the Copas scheduler. 
-    	Takes a <code>thread</code> created by <code>copas.addthread()</code> and removes
-		it from the disptacher the next time it tries to resume. If <code>thread</code> isn't 
-		registered,	it does nothing.
+
+    <dt><strong><code>copas.removethread(coroutine)</code></strong></dt>
+    <dd>Removes a coroutine added to the Copas scheduler. 
+        Takes a <code>coroutine</code> created by <code>copas.addthread()</code> and removes
+        it from the disptacher the next time it tries to resume. If <code>coroutine</code> isn't
+        registered, it does nothing.
     </dd>
 
     <dt><strong><code>copas.running</code></strong></dt>

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -631,11 +631,11 @@ function copas.addthread(handler, ...)
   return thread
 end
 
-function copas.removethread(thread)
-    if not thread then return end
-    -- if the specified thread is registered, add it to the canceled table so
-    -- that next time it tries to resume it exits. 
-    _canceled[thread] = _threads[thread]   
+function copas.removethread(coroutine)
+    if not coroutine then return end
+    -- if the specified coroutine is registered, add it to the canceled table so
+    -- that next time it tries to resume it exits.
+    _canceled[coroutine] = _threads[coroutine]
 end
 
 -------------------------------------------------------------------------------

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -632,6 +632,7 @@ function copas.addthread(handler, ...)
 end
 
 function copas.removethread(thread)
+    if not thread then return end
     -- if the specified thread is registered, add it to the canceled table so
     -- that next time it tries to resume it exits. 
     _canceled[thread] = _threads[thread]   

--- a/tests/removethread.lua
+++ b/tests/removethread.lua
@@ -1,0 +1,28 @@
+--- Test for removethread(thread)
+
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+
+local copas = require("copas")
+local socket = require("socket")
+
+local t1 = copas.addthread(
+    function()
+        print("endless thread start")
+        local n = 0
+        while true do
+           n = n + 1
+           print("endless thread:",n)
+           copas.sleep(0.5)
+        end
+    end)
+
+copas.addthread(function()
+   for i = 1, 5 do
+      copas.sleep(0.6)
+   end
+   print("stopping endless thread externally")
+   copas.removethread(t1)
+end)
+
+copas.loop()


### PR DESCRIPTION
It is sometimes preferred to stop a registered thread externally (#68) and currently there is no remove thread option. This PR adds a remove thread function to accomplish this.