### PR TITLE
add socket timeouts

### DIFF
--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -1,0 +1,130 @@
+-- Tests Copas socket timeouts
+--
+-- Run the test file, it should exit successfully without hanging.
+
+local copas = require("copas")
+local socket = require("socket")
+
+-- hack; no way to kill copas.loop from thread
+local function error(err)
+  print(debug.traceback(err, 2))
+  os.exit(-1)
+end
+local function assert(truthy, err)
+  if not truthy then
+    print(debug.traceback(err, 2))
+    os.exit(-1)
+  end
+end
+
+-- tcp echo server for testing against, returns `ip, port` to connect to
+-- send `quit\n` to cause server to disconnect client
+-- stops listen server after first connection
+local function singleuseechoserver()
+  local server = socket.bind("127.0.0.1", 0) -- "localhost" fails because of IPv6 error
+  local ip, port = server:getsockname()
+
+  local function echoHandler(skt)
+    -- remove server after first connection
+    copas.removeserver(server)
+
+    skt = copas.wrap(skt)
+    while true do
+      local data = skt:receive()
+      if not data or data == "quit" then
+        break
+      end
+      print("server data ("..#data.."):", data)
+      skt:send(data..'\n')
+    end
+
+    print("server end")
+  end
+
+  copas.addserver(server, echoHandler)
+
+  return ip, port
+end
+
+local tests = {}
+
+function tests.just_exit()
+  print("loop")
+  copas.loop()
+end
+
+function tests.connect_and_exit()
+  local ip, port = singleuseechoserver()
+  copas.addthread(function()
+    print("connect", ip, port)
+    local client = socket.connect(ip, port)
+    client = copas.wrap(client)
+
+    client:close()
+  end)
+
+  print("loop")
+  copas.loop()
+end
+
+function tests.connect_timeout()
+  local server = socket.tcp()
+  server:bind("localhost", 0)
+  server:listen(0) -- zero backlog, single connection will block further connections
+  -- note: not servicing connections
+  local ip, port = server:getsockname()
+
+  copas.addthread(function()
+    -- fill server's implicit connection backlog
+    socket.connect(ip,port)
+
+    local client = socket.tcp()
+    client = copas.wrap(client)
+    client:settimeout(1)
+    print("connect:", ip, port)
+    local status, err = client:connect(ip, port)
+    assert(status == nil, "connect somehow succeeded")
+    assert(err == "timeout", "connect failed with non-timeout error: "..err)
+    client:close()
+  end)
+
+  print("loop")
+  copas.loop()
+end
+
+function tests.receive_timeout()
+  local ip, port = singleuseechoserver()
+
+  copas.addthread(function()
+    local client = socket.tcp()
+    client = copas.wrap(client)
+    client:settimeout(0.01)
+    local status, err = client:connect(ip, port)
+    assert(status, "failed to connect: "..tostring(err))
+
+    client:send("foo\n")
+    local data, err = client:receive()
+    assert(data, "failed to recieve: "..tostring(err))
+    assert(data == "foo", "recieved wrong echo: "..tostring(data))
+
+    local data, err = client:receive()
+    assert(data == nil, "somehow recieved echo without sending")
+    assert(err == "timeout", "failed with non-timeout error")
+
+    client:close()
+  end)
+
+  print("loop")
+  copas.loop()
+end
+
+-- test "framework"
+for name, test in pairs(tests) do
+  print("testing: "..tostring(name))
+  local status, err = pcall(test)
+  if not status then
+    error(err)
+  end
+end
+
+print("[✓] all tests completed successuly")

--- a/tests/tcptimeout.lua
+++ b/tests/tcptimeout.lua
@@ -34,11 +34,8 @@ local function singleuseechoserver()
       if not data or data == "quit" then
         break
       end
-      print("server data ("..#data.."):", data)
       skt:send(data..'\n')
     end
-
-    print("server end")
   end
 
   copas.addserver(server, echoHandler)
@@ -49,21 +46,18 @@ end
 local tests = {}
 
 function tests.just_exit()
-  print("loop")
   copas.loop()
 end
 
 function tests.connect_and_exit()
   local ip, port = singleuseechoserver()
   copas.addthread(function()
-    print("connect", ip, port)
     local client = socket.connect(ip, port)
     client = copas.wrap(client)
 
     client:close()
   end)
 
-  print("loop")
   copas.loop()
 end
 
@@ -80,15 +74,13 @@ function tests.connect_timeout()
 
     local client = socket.tcp()
     client = copas.wrap(client)
-    client:settimeout(1)
-    print("connect:", ip, port)
+    client:settimeout(0.01)
     local status, err = client:connect(ip, port)
     assert(status == nil, "connect somehow succeeded")
-    assert(err == "timeout", "connect failed with non-timeout error: "..err)
+    assert(err == "Operation already in progress", "connect failed with non-timeout error: "..err)
     client:close()
   end)
 
-  print("loop")
   copas.loop()
 end
 
@@ -114,7 +106,6 @@ function tests.receive_timeout()
     client:close()
   end)
 
-  print("loop")
   copas.loop()
 end
 

--- a/tests/udptimeout.lua
+++ b/tests/udptimeout.lua
@@ -33,12 +33,9 @@ local function singleuseechoserver(die_after)
       if not data or data == "quit" then
         break
       end
-      print("server data ("..#data.."):", data)
       skt:sendto(data, ip, port)
       die_after = die_after - 1
     end
-
-    print("server end")
   end)
 
   return ip, port
@@ -68,7 +65,6 @@ function tests.receive_timeout()
     client:close()
   end)
 
-  print("loop")
   copas.loop()
 end
 
@@ -92,7 +88,6 @@ function tests.receivefrom_timeout()
     client:close()
   end)
 
-  print("loop")
   copas.loop()
 end
 

--- a/tests/udptimeout.lua
+++ b/tests/udptimeout.lua
@@ -1,0 +1,108 @@
+-- Tests Copas socket timeouts
+--
+-- Run the test file, it should exit successfully without hanging.
+
+local copas = require("copas")
+local socket = require("socket")
+
+-- hack; no way to kill copas.loop from thread
+local function error(err)
+  print(debug.traceback(err, 2))
+  os.exit(-1)
+end
+local function assert(truthy, err)
+  if not truthy then
+    print(debug.traceback(err, 2))
+    os.exit(-1)
+  end
+end
+
+-- udp echo server for testing against, returns `ip, port` to connect to
+-- send `quit\n` to cause server to disconnect client
+-- stops listen server after provided number of echos
+local function singleuseechoserver(die_after)
+  local die_after = die_after or 1
+  local server = socket.udp()
+  server:setsockname("127.0.0.1", 0) -- "localhost" fails because of IPv6 error
+  local ip, port = server:getsockname()
+
+  copas.addthread(function()
+    local skt = copas.wrap(server)
+    while die_after > 0 do
+      local data, ip, port = skt:receivefrom()
+      if not data or data == "quit" then
+        break
+      end
+      print("server data ("..#data.."):", data)
+      skt:sendto(data, ip, port)
+      die_after = die_after - 1
+    end
+
+    print("server end")
+  end)
+
+  return ip, port
+end
+
+local tests = {}
+
+function tests.receive_timeout()
+  local ip, port = singleuseechoserver(1)
+
+  copas.addthread(function()
+    local client = socket.udp()
+    client = copas.wrap(client)
+    client:settimeout(0.01)
+    local status, err = client:setpeername(ip, port)
+    assert(status, "failed to connect: "..tostring(err))
+
+    client:send("foo")
+    local data, err = client:receive()
+    assert(data, "failed to recieve: "..tostring(err))
+    assert(data == "foo", "recieved wrong echo: "..tostring(data))
+
+    local data, err = client:receive()
+    assert(data == nil, "somehow recieved echo without sending")
+    assert(err == "timeout", "failed with non-timeout error")
+
+    client:close()
+  end)
+
+  print("loop")
+  copas.loop()
+end
+
+function tests.receivefrom_timeout()
+  local ip, port = singleuseechoserver(1)
+
+  copas.addthread(function()
+    local client = socket.udp()
+    client = copas.wrap(client)
+    client:settimeout(0.01)
+
+    client:sendto("foo", ip, port)
+    local data, err = client:receivefrom()
+    assert(data, "failed to recieve: "..tostring(err))
+    assert(data == "foo", "recieved wrong echo: "..tostring(data))
+
+    local data, err = client:receivefrom()
+    assert(data == nil, "somehow recieved echo without sending")
+    assert(err == "timeout", "failed with non-timeout error")
+
+    client:close()
+  end)
+
+  print("loop")
+  copas.loop()
+end
+
+-- test "framework"
+for name, test in pairs(tests) do
+  print("testing: "..tostring(name))
+  local status, err = pcall(test)
+  if not status then
+    error(err)
+  end
+end
+
+print("[✓] all tests completed successuly")


### PR DESCRIPTION
Note: This is PR isn't 100% ready to merge, but has been functional in my (manual) testing. I just wanted to get this up a bit early to see if anyone more familiar with the code base is available to give it a once over before I go back and refine things.

Also, I actually wrote this almost a year ago doing some proof of concept hacking, so I might not have answers to "why did you do this this way" kinds of questions.

Mostly, my question is: I'm tracking user timeouts in a completely new set of tables `_usersockettimeouts` and `_usertimedoutsockets` (and the `_usertimeouts` interface). Is this the right way to go about this. Is there something that already exists that I've overlooked that I should be leveraging instead?

I don't remember if I actually tested UDP (or exactly which TCP APIs I tested for that matter). Any other things I should add timeouts to/make sure work?