### PR TITLE
Add SNI support

### DIFF
--- a/src/copas.lua
+++ b/src/copas.lua
@@ -364,11 +364,11 @@ end
 -- @param skt Regular LuaSocket CLIENT socket object
 -- @param sslt Table with ssl parameters
 -- @return wrapped ssl socket, or throws an error
-function copas.dohandshake(skt, sslt, sni)
+function copas.dohandshake(skt, sslt)
   ssl = ssl or require("ssl")
   local nskt, err = ssl.wrap(skt, sslt)
   if not nskt then return error(err) end
-  if sni then nskt:sni(sni) end
+  if sslt.hostname then nskt:sni(sslt.hostname) end
   local queue
   nskt:settimeout(0)
   repeat
@@ -452,7 +452,7 @@ local _skt_mt_tcp = {
 
                    dohandshake = function(self, sslt)
                      self.ssl_params = sslt or self.ssl_params
-                     local nskt, err = copas.dohandshake(self.socket, self.ssl_params, self.sni_hostname)
+                     local nskt, err = copas.dohandshake(self.socket, self.ssl_params)
                      if not nskt then return nskt, err end
                      self.socket = nskt  -- replace internal socket with the newly wrapped ssl one
                      return self
@@ -492,7 +492,7 @@ _skt_mt_udp.__index.close       = function(self, ...) return true end
 -- @param skt The socket to wrap
 -- @sslt (optional) Table with ssl parameters, use an empty table to use ssl with defaults
 -- @return wrapped socket object
-function copas.wrap (skt, sslt, sni)
+function copas.wrap (skt, sslt)
   if (getmetatable(skt) == _skt_mt_tcp) or (getmetatable(skt) == _skt_mt_udp) then
     return skt -- already wrapped
   end
@@ -500,7 +500,7 @@ function copas.wrap (skt, sslt, sni)
   if not isTCP(skt) then
     return  setmetatable ({socket = skt}, _skt_mt_udp)
   else
-    return  setmetatable ({socket = skt, ssl_params = sslt, sni_hostname = sni}, _skt_mt_tcp)
+    return  setmetatable ({socket = skt, ssl_params = sslt}, _skt_mt_tcp)
   end
 end
 

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -372,7 +372,7 @@ function copas.dohandshake(skt, sslt, hostname, strict)
   if not nskt then return error(err) end
   if type(hostname) == 'table' then
     nskt:sni(hostname, strict)
-  else if hostname then
+  elseif hostname then
     nskt:sni(hostname)
   end
   local queue
@@ -496,19 +496,19 @@ _skt_mt_udp.__index.close       = function(self, ...) return true end
 ---
 -- Wraps a LuaSocket socket object in an async Copas based socket object.
 -- @param skt The socket to wrap
--- @sslt (optional) Table with ssl parameters, use an empty table to use ssl with defaults
--- @hostname (optional) SNI host name
--- @strict (optional) If true, the handshake will fail with a non-existing SNI hostname
+-- @param sslt (optional) Table with ssl parameters, use an empty table to use ssl with defaults
+-- @param hostname (optional) SNI host name
+-- @param strict (optional) If true, the handshake will fail with a non-existing SNI hostname
 -- @return wrapped socket object
-function copas.wrap (skt, sslt, hst, str)
+function copas.wrap (skt, sslt, hostname, strict)
   if (getmetatable(skt) == _skt_mt_tcp) or (getmetatable(skt) == _skt_mt_udp) then
     return skt -- already wrapped
   end
   skt:settimeout(0)
   if not isTCP(skt) then
-    return  setmetatable ({socket = skt, hostname = host, strict = str}, _skt_mt_udp)
+    return  setmetatable ({socket = skt, hostname = hostname, strict = strict}, _skt_mt_udp)
   else
-    return  setmetatable ({socket = skt, ssl_params = sslt, hostname = host, strict = str}, _skt_mt_tcp)
+    return  setmetatable ({socket = skt, ssl_params = sslt, hostname = hostname, strict = strict}, _skt_mt_tcp)
   end
 end
 

--- a/src/copas/http.lua
+++ b/src/copas/http.lua
@@ -357,6 +357,7 @@ local function tcp(params)
       if (reqt.scheme or u.scheme) == "https" then
         -- insert hostname for SNI
         params.hostname = params.hostname or reqt.host
+        params.strict = false -- Client mode
         -- https, provide an ssl wrapped socket
         local conn = copas.wrap(socket.tcp(), params)
         -- insert https default port, overriding http port inserted by LuaSocket

--- a/src/copas/http.lua
+++ b/src/copas/http.lua
@@ -356,7 +356,7 @@ local function tcp(params)
       local u = url.parse(reqt.url)
       if (reqt.scheme or u.scheme) == "https" then
         -- https, provide an ssl wrapped socket
-        local conn = copas.wrap(socket.tcp(), params)
+        local conn = copas.wrap(socket.tcp(), params, reqt.host)
         -- insert https default port, overriding http port inserted by LuaSocket
         if not u.port then
            u.port = _M.SSLPORT

--- a/src/copas/http.lua
+++ b/src/copas/http.lua
@@ -355,8 +355,10 @@ local function tcp(params)
    return function (reqt)
       local u = url.parse(reqt.url)
       if (reqt.scheme or u.scheme) == "https" then
+        -- insert hostname for SNI
+        params.hostname = params.hostname or reqt.host
         -- https, provide an ssl wrapped socket
-        local conn = copas.wrap(socket.tcp(), params, reqt.host)
+        local conn = copas.wrap(socket.tcp(), params)
         -- insert https default port, overriding http port inserted by LuaSocket
         if not u.port then
            u.port = _M.SSLPORT


### PR DESCRIPTION
This pull request fixes #77 by adding SNI support for Copas.

It can be tested by accessing a site behind Cloudflare. I tried with the `emoji-downloader` rock:
```
emoji-downloader cybre.space
```