### PR TITLE
fix(limit) improve performance of big limit sets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -108,6 +108,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
                 <li>Fixed: type in wrapped udp:setpeername was actually calling udp:getpeername</li>
                 <li>Added: copas.removethread() added to be able to forcefully remove a previously added thread</li>
                 <li>Fixed: default error handler didn't print the stacktrace</li>
+                <li>Change: performance improvement in big limit-sets</li>
 	</ul></dd>
 
     <dt><strong>Copas 2.0.2</strong> [2017]</dt>

--- a/src/copas/limit.lua
+++ b/src/copas/limit.lua
@@ -14,6 +14,50 @@ if _VERSION=="Lua 5.1" and not jit then     -- obsolete: only for Lua 5.1 compat
   pcall = require("coxpcall").pcall
 end
 
+local ll = {}
+ll.__index = ll
+
+function ll:push(item)
+  self.last = { item = item, prev = self.last }
+  if not self.first then
+    self.first = self.last -- no last, so list is empty, set as first to
+  else
+    self.last.prev.next = self.last -- point previous end to new end
+  end
+end
+function ll:pop()
+  if not self.first then
+    return  -- list is empty
+  end
+  local entry = self.first.item
+  self.first = self.first.next
+  if self.first then
+    self.first.prev = nil
+  else
+    self.last = nil
+  end
+  return entry
+end
+function ll:remove(item)  --> first occurence of item will be removed
+  local entry = self.first
+  while true do
+    if not entry then return end -- end of list, not found
+    if entry.item == item then
+      local prev = entry.prev or {}
+      local nxt = entry.next or {}
+      prev.next = entry.next
+      nxt.prev = entry.prev
+      if self.first == entry then self.first = entry.next end
+      if self.last == entry then self.last = entry.prev end
+      return
+    end
+    entry = entry.next
+  end
+end
+function ll.new()
+  return setmetatable({}, ll)
+end
+
 -- Add a task to the queue, returns the coroutine created
 -- identical to `copas.addthread`. Can be called while the
 -- set of tasks is executing.
@@ -25,7 +69,7 @@ local function add(self, task, ...)
       self:removethread(coroutine.running())           -- dismiss ourselves
       if not suc then error(err) end             -- rethrow error
     end)
-  table.insert(self.queue, coro)                 -- store in list
+  self.queue:push(coro)                          -- store in list
   self:next()
   return coro
 end
@@ -34,19 +78,13 @@ end
 -- set of tasks is executing. Will NOT stop the task if
 -- it is already running.
 local function remove(self, coro)
-  self.queue[coro] = nil
   if self.running[coro] then
     -- it is in the already running set
     self.running[coro] = nil
     self.count = self.count - 1
   else
     -- check the queue and remove if found
-    for i, item in ipairs(self.queue) do
-      if coro == item then
-        table.remove(self.queue, i)
-        break
-      end
-    end
+    self.queue:remove(coro)
   end
   self:next()
 end
@@ -54,10 +92,9 @@ end
 -- schedules the next task (if any) for execution, signals completeness
 local function nxt(self)
   while self.count < self.maxt do
-    local coro = self.queue[1]
+    local coro = self.queue:pop()
     if not coro then break end -- queue is empty, so nothing to add
     -- move it to running and restart the task
-    table.remove(self.queue, 1)
     self.running[coro] = coro
     self.count = self.count + 1
     copas.wakeup(coro)
@@ -85,7 +122,7 @@ local function new(maxt)
   return {
     maxt = maxt or 99999,     -- max simultaneous tasks
     count = 0,                -- count of running tasks
-    queue = {},               -- tasks waiting (list/array)
+    queue = ll.new(),         -- tasks waiting (linked list)
     running = {},             -- tasks currently running (indexed by coroutine)
     waiting = {},             -- coroutines, waiting for all tasks being finished (indexed by coro)
     addthread = add,


### PR DESCRIPTION
A test set of 1,000,000 tasks reduced from 4.x seconds to 0.3x.
This is an alternative implementation of PR #73 by @fcr-- , without
the size limitation.

closes #73