### PR TITLE
feat(loop) add an optional initialization function to 'loop'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/removeserver.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/removethread.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/sleep.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/loop_starter.lua
 	$(LUA) $(DELIM)
 
 coverage:

--- a/docs/index.html
+++ b/docs/index.html
@@ -110,6 +110,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
                 <li>Fixed: default error handler didn't print the stacktrace</li>
                 <li>Change: performance improvement in big limit-sets</li>
                 <li>Fixed: small memory leak when sleeping until woken</li>
+                <li>Change: copas.loop() now takes an optional initialization function</li>
 	</ul></dd>
 
     <dt><strong>Copas 2.0.2</strong> [2017]</dt>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -97,12 +97,14 @@ are used to register servers and to execute the main loop of Copas:</p>
         See also <code>copas.running</code>.
     </dd>
 
-    <dt><strong><code>copas.loop([timeout])</code></strong></dt>
+    <dt><strong><code>copas.loop([init_func, ][timeout])</code></strong></dt>
     <dd>Starts the Copas loop accepting client connections for the
         registered servers and handling those connections with the corresponding
         handlers. Every time a server accepts a connection, Copas calls the
         associated handler passing the client socket returned by
-        <code>socket.accept()</code>. The <code>timeout</code> parameter is optional,
+        <code>socket.accept()</code>. The <code>init_func</code> function is an
+        optional initialization function that runs as a Copas thread. 
+        The <code>timeout</code> parameter is optional,
         and is passed to the <code>copas.step()</code> function.
         The loop returns when <code>copas.finished() == true</code>.
     </dd>

--- a/src/copas.lua
+++ b/src/copas.lua
@@ -724,11 +724,12 @@ function copas.wakeup(co)
     _sleeping:wakeup(co)
 end
 
-local last_cleansing = 0
 
 -------------------------------------------------------------------------------
 -- Checks for reads and writes on sockets
 -------------------------------------------------------------------------------
+local last_cleansing = 0
+
 local function _select (timeout)
   local err
   local now = gettime()
@@ -817,7 +818,13 @@ end
 -- Dispatcher endless loop.
 -- Listen to client requests and handles them forever
 -------------------------------------------------------------------------------
-function copas.loop(timeout)
+function copas.loop(initializer, timeout)
+  if type(initializer) == "function" then
+    copas.addthread(initializer)
+  else
+    timeout = initializer or timeout
+  end
+
   copas.running = true
   while not copas.finished() do copas.step(timeout) end
   copas.running = false

--- a/tests/loop_starter.lua
+++ b/tests/loop_starter.lua
@@ -1,0 +1,13 @@
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+local copas = require "copas"
+
+local x
+
+copas.loop(function()
+  -- Copas initialization function
+  x = true
+end)
+
+assert(x, "expected 'x' to be truthy")
+print "test success!"

--- a/tests/removethread.lua
+++ b/tests/removethread.lua
@@ -42,3 +42,4 @@ collectgarbage()
 
 --check GC
 assert(next(validate_gc) == nil, "the 'validate_gc' table should have been empty!")
+print "test success!"

--- a/tests/sleep.lua
+++ b/tests/sleep.lua
@@ -26,3 +26,5 @@ collectgarbage()
 
 --check GC
 assert(next(validate_gc) == nil, "the 'validate_gc' table should have been empty!")
+
+print "test success!"


### PR DESCRIPTION
this code:
```lua
  copas.addthread(function()
    -- do initialization
  end

  copas.loop()
```
can now be written as
```lua
  copas.loop(function()
    -- do initialization
  end)
```

Backwards compatible and slightly nicer if, during initialization, you need the scheduler to already be running.
