### PR TITLE
feat(timer) adds a timer class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/removethread.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/sleep.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/loop_starter.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/timer.lua
 	$(LUA) $(DELIM)
 
 coverage:

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -338,23 +338,24 @@ copas.loop()
 example passing arguments to a task, see the async http example below.</p>
 
 <h2><a name="timers"></a>Creating timers</h2>
-<p>Timers can be created using the <code>addthread</code> method with the <code>sleep</code> method. 
-Below an example of a thread being added to create and used as a timer;</p>
+<p>Timers can be created using the <code>copas.timer</code> module.
+Below an example of a timer;</p>
 <pre class="example">
 local copas = require("copas")
+local timer = require("copas.timer")
 
-copas.addthread(function()
-   print("This will print immediately, upon adding the thread. So before the loop starts")
-   while true do
-      copas.sleep(1) -- 1 second interval
-      print("Hello there!")
-   end
+copas.loop(function()
+   timer.new({
+     delay = 1,                        -- delay in seconds
+     recurring = true,                 -- make the timer repeat
+     callback = function(timer_obj, params)
+       print(params)                   -- prints "hello world"
+       timer_obj:cancel()              -- cancel the timer after 1 occurence
+     end
+   }, "hello world")
 end)
-
-print("We're starting!")
-copas.loop()
 </pre>
-<p>The example simply prints a message once every second.</p>
+<p>The example simply prints a message once every second, but gets cancelled right after the first one.</p>
 
 <h2><a name="ssl"></a>Ssl support</h2>
 <p>LuaSec is transparently integrated in the Copas scheduler (though must be installed separately when using LuaRocks).</p>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -348,11 +348,12 @@ copas.loop(function()
    timer.new({
      delay = 1,                        -- delay in seconds
      recurring = true,                 -- make the timer repeat
+     params = "hello world",
      callback = function(timer_obj, params)
        print(params)                   -- prints "hello world"
        timer_obj:cancel()              -- cancel the timer after 1 occurence
      end
-   }, "hello world")
+   })
 end)
 </pre>
 <p>The example simply prints a message once every second, but gets cancelled right after the first one.</p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -225,12 +225,17 @@ exchange data with other services.</p>
     <code>copas.dohandshake()</code>). To use ssl with defaults; provide an empty table.
     </dd>
 
-    <dt><strong><code>timer.new(options, [params], [initial_delay])</code></strong></dt>
-    <dd>Creates and returns an (armed) `timer`. The <code>options</code> table has 3 fields;
-    <code>options.recurring</code> boolean, <code>options.delay</code> (in seconds), and
-    <code>options.callback</code> with the function to execute on timer expiry.
-    The callback function has <code>function(timer_obj, params)</code> as signature, where
-    <code>params</code> is the value initially passed to <code>timer.new</code>.
+    <dt><strong><code>timer.new(options)</code></strong></dt>
+    <dd>Creates and returns an (armed) timer object. The <code>options</code> table has the following fields;
+    <ul>
+        <li><code>options.recurring</code> boolean</li>
+        <li><code>options.delay</code> expiry delay in seconds</li>
+        <li><code>options.initial_delay</code> (optional) see <code>timer:arm()</code></li>
+        <li><code>options.params</code> (optional) an opaque value that is passed to the callback upon expiry</li>
+        <li><code>options.callback</code> is the function to execute on timer expiry.
+            The callback function has <code>function(timer_obj, params)</code> as signature, where
+            <code>params</code> is the value initially passed in <code>options.params</code></li>
+    </ul>
     </dd>
 
     <dt><strong><code>timer:arm([initial_delay])</code></strong></dt>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -225,6 +225,25 @@ exchange data with other services.</p>
     <code>copas.dohandshake()</code>). To use ssl with defaults; provide an empty table.
     </dd>
 
+    <dt><strong><code>timer.new(options, [params], [initial_delay])</code></strong></dt>
+    <dd>Creates and returns an (armed) `timer`. The <code>options</code> table has 3 fields;
+    <code>options.recurring</code> boolean, <code>options.delay</code> (in seconds), and
+    <code>options.callback</code> with the function to execute on timer expiry.
+    The callback function has <code>function(timer_obj, params)</code> as signature, where
+    <code>params</code> is the value initially passed to <code>timer.new</code>.
+    </dd>
+
+    <dt><strong><code>timer:arm([initial_delay])</code></strong></dt>
+    <dd>Arms a timer that was previously cancelled or exited. Returns the timer. 
+    The optional parameter <code>initial_delay</code>, determines the first delay.
+    For example a recurring timer with <code>delay = 5</code>, and <code>initial_delay = 0</code> will
+    execute immediately and then recur every 5 seconds.
+    </dd>
+
+    <dt><strong><code>timer:cancel()</code></strong></dt>
+    <dd>Will cancel the timer.
+    </dd>
+
 </dl>
 
 <h3>High level request functions</h3>
@@ -279,6 +298,7 @@ servers.</br>
     <dt><strong><code>limitset:wait()</code></strong></dt>
     <dd>Will yield until all tasks in the set have finished.
     </dd>
+
 </dl>
 
 </div> <!-- id="content" -->

--- a/src/copas/timer.lua
+++ b/src/copas/timer.lua
@@ -1,0 +1,87 @@
+local copas = require("copas")
+
+
+
+local timer = {}
+timer.__index = timer
+
+
+
+do
+  local function expire_func(self, initial_delay)
+    copas.sleep(initial_delay)
+    while true do
+      if not self.cancelled then
+        self.callback(self, self.params)
+      end
+
+      if (not self.recurring) or self.cancelled then
+        -- clean up and exit the thread
+        self.co = nil
+        self.cancelled = true
+        return
+      end
+
+      copas.sleep(self.delay)
+    end
+  end
+
+
+  --- Arms the timer object.
+  -- @param initial_delay (optional) the first delay to use, if not provided uses the timer delay
+  -- @return timer object, nil+error, or throws an error on bad input
+  function timer:arm(initial_delay)
+    assert(initial_delay == nil or initial_delay >= 0, "delay must be greater than or equal to 0")
+    if self.co then
+      return nil, "already armed"
+    end
+
+    self.cancelled = false
+    self.co = copas.addthread(expire_func, self, initial_delay or self.delay)
+    return self
+  end
+end
+
+
+
+--- Cancels a running timer.
+-- @return timer object, or nil+error
+function timer:cancel()
+  if not self.co then
+    return nil, "not armed"
+  end
+
+  if self.cancelled then
+    return nil, "already cancelled"
+  end
+
+  self.cancelled = true
+  copas.wakeup(self.co)       -- resume asap
+  copas.removethread(self.co) -- will immediately drop the thread upon resuming
+  self.co = nil
+  return self
+end
+
+
+
+--- Creates a new timer object.
+-- Note: the callback signature is: `function(timer_obj, params)`.
+-- @param opts (table) `opts.delay` timer delay in seconds, `opts.callback` function to execute, `opts.recurring` boolean
+-- @param param (optional) this value will be passed to the timer callback
+-- @param initial_delay (optional) the first delay to use, if not provided uses the timer delay
+-- @return timer object, or throws an error on bad input
+function timer.new(opts, params, initial_delay)
+  assert(opts.delay >= 0, "delay must be greater than or equal to 0")
+  assert(type(opts.callback) == "function", "expected callback to be a function")
+  return setmetatable({
+    delay = opts.delay,
+    callback = opts.callback,
+    recurring = not not opts.recurring,
+    params = params,
+    cancelled = false,
+  }, timer):arm(initial_delay)
+end
+
+
+
+return timer

--- a/src/copas/timer.lua
+++ b/src/copas/timer.lua
@@ -12,7 +12,7 @@ do
     copas.sleep(initial_delay)
     while true do
       if not self.cancelled then
-        self.callback(self, self.params)
+        self:callback(self.params)
       end
 
       if (not self.recurring) or self.cancelled then
@@ -67,19 +67,18 @@ end
 --- Creates a new timer object.
 -- Note: the callback signature is: `function(timer_obj, params)`.
 -- @param opts (table) `opts.delay` timer delay in seconds, `opts.callback` function to execute, `opts.recurring` boolean
--- @param param (optional) this value will be passed to the timer callback
--- @param initial_delay (optional) the first delay to use, if not provided uses the timer delay
+-- `opts.params` (optional) this value will be passed to the timer callback, `opts.initial_delay` (optional) the first delay to use, defaults to `delay`.
 -- @return timer object, or throws an error on bad input
-function timer.new(opts, params, initial_delay)
+function timer.new(opts)
   assert(opts.delay >= 0, "delay must be greater than or equal to 0")
   assert(type(opts.callback) == "function", "expected callback to be a function")
   return setmetatable({
     delay = opts.delay,
     callback = opts.callback,
     recurring = not not opts.recurring,
-    params = params,
+    params = opts.params,
     cancelled = false,
-  }, timer):arm(initial_delay)
+  }, timer):arm(opts.initial_delay)
 end
 
 

--- a/tests/timer.lua
+++ b/tests/timer.lua
@@ -9,32 +9,36 @@ local timer = require "copas.timer"
 
 
 copas.loop(function()
+
   local count_t1 = 0
   local t1 = timer.new({
     delay = 0.5,
     recurring = true,
-    callback = function(timer_obj, param)
+    params = "hello world",
+    callback = function(timer_obj, params)
       -- let's ensure parameters get passed
-      assert(param == "hello world", "expected: hello world")
+      assert(params == "hello world", "expected: hello world")
       count_t1 = count_t1 + 1
-      print(param .. " " .. count_t1)
+      print(params .. " " .. count_t1)
     end,
-  }, "hello world")
+  })
 
   local t2 = timer.new({
     delay = 0.2,  -- we'll override this with 0.1 below
     recurring = false,
-    callback = function(timer_obj, param)
-      assert(gettime() - param.start_time < 0.11, "didn't honour initial delay, or recurred")
+    params = {
+      start_time = gettime()
+    },
+    initial_delay = 0.1,  -- initial delay, only 0.1
+    callback = function(timer_obj, params)
+      assert(gettime() - params.start_time < 0.11, "didn't honour initial delay, or recurred")
       print("this seems to go well, and should print only once")
     end,
-  }, {
-    start_time = gettime()
-  }, 0.1) -- initial delay, only 0.1
+  })
 
   timer.new({
     delay = 3.3,  --> allows T1 to run 6 times
-    callback = function(timer_obj, param)
+    callback = function(timer_obj, params)
       t1:cancel()
       local _, err = t2:cancel()
       assert(err == "not armed", "expected t2 to already be stopped")

--- a/tests/timer.lua
+++ b/tests/timer.lua
@@ -1,0 +1,47 @@
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+
+
+
+local copas = require "copas"
+local gettime = require("socket").gettime
+local timer = require "copas.timer"
+
+
+copas.loop(function()
+  local count_t1 = 0
+  local t1 = timer.new({
+    delay = 0.5,
+    recurring = true,
+    callback = function(timer_obj, param)
+      -- let's ensure parameters get passed
+      assert(param == "hello world", "expected: hello world")
+      count_t1 = count_t1 + 1
+      print(param .. " " .. count_t1)
+    end,
+  }, "hello world")
+
+  local t2 = timer.new({
+    delay = 0.2,  -- we'll override this with 0.1 below
+    recurring = false,
+    callback = function(timer_obj, param)
+      assert(gettime() - param.start_time < 0.11, "didn't honour initial delay, or recurred")
+      print("this seems to go well, and should print only once")
+    end,
+  }, {
+    start_time = gettime()
+  }, 0.1) -- initial delay, only 0.1
+
+  timer.new({
+    delay = 3.3,  --> allows T1 to run 6 times
+    callback = function(timer_obj, param)
+      t1:cancel()
+      local _, err = t2:cancel()
+      assert(err == "not armed", "expected t2 to already be stopped")
+      assert(count_t1 == 6, "expected t1 to run 6 times!")
+      timer_obj:cancel()  -- cancel myself
+    end,
+  })
+
+end)
+print("test success!")


### PR DESCRIPTION
previously timers had to be created by adding a thread and then using `sleep` to get the desired behaviour.

This is now abstracted in a class.
