### PR TITLE
feat(core) added timeouts interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/sleep.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/loop_starter.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/timer.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/lock.lua
 	$(LUA) $(DELIM)
 
 coverage:

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,7 +111,9 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
                 <li>Change: performance improvement in big limit-sets</li>
                 <li>Fixed: small memory leak when sleeping until woken</li>
                 <li>Change: copas.loop() now takes an optional initialization function</li>
-                <li>Added: timeout interface settimeout() and canceltimeout()</li>
+                <li>Added: timer class, see module "copas.timer"</li>
+                <li>Added: timeout interface copas.settimeout() and copas.canceltimeout()</li>
+                <li>Added: lock class, see module "copas.lock"</li>
 	</ul></dd>
 
     <dt><strong>Copas 2.0.2</strong> [2017]</dt>

--- a/docs/index.html
+++ b/docs/index.html
@@ -111,6 +111,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
                 <li>Change: performance improvement in big limit-sets</li>
                 <li>Fixed: small memory leak when sleeping until woken</li>
                 <li>Change: copas.loop() now takes an optional initialization function</li>
+                <li>Added: timeout interface settimeout() and canceltimeout()</li>
 	</ul></dd>
 
     <dt><strong>Copas 2.0.2</strong> [2017]</dt>

--- a/docs/manual.html
+++ b/docs/manual.html
@@ -358,6 +358,34 @@ end)
 </pre>
 <p>The example simply prints a message once every second, but gets cancelled right after the first one.</p>
 
+<h2><a name="locks"></a>Using locks</h2>
+<p>Since Copas allows to asynchroneously schedule tasks, locks might be required
+to protect resources from concurrent access. In this case the <code>copas.lock</code> class
+can be used. A lock will ensure that the coroutine running will be yielded until
+the protected resource becomes available, without blocking other threads.
+</p>
+<pre class="example">
+local copas = require("copas")
+local new_lock = require("copas.lock").new
+
+local lock = new_lock()
+
+local function some_func()
+  local ok, err, wait = lock:get()
+  if not ok then
+    return nil, "we got error '" .. err .. "' after " .. wait .. " seconds"
+  end
+
+  print("doing something on my own")
+  copas.sleep()  -- allow to yield, while inside the lock
+  print("after " .. ok .. " seconds waiting")
+
+  lock:release()
+end
+</pre>
+<p>The <code>some_func</code> function may now be called and the 2 lines will
+be printed together because of the lock.</p>
+
 <h2><a name="ssl"></a>Ssl support</h2>
 <p>LuaSec is transparently integrated in the Copas scheduler (though must be installed separately when using LuaRocks).</p>
 <p>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -240,6 +240,33 @@ exchange data with other services.</p>
     <code>copas.dohandshake()</code>). To use ssl with defaults; provide an empty table.
     </dd>
 
+    <dt><strong><code>lock:destroy()</code></strong></dt>
+    <dd>Will destroy the lock and release all waiting threads. The result for those
+    threads will be <code>nil + "destroyed" + wait_time</code>.
+    </dd>
+
+    <dt><strong><code>lock:get([timeout])</code></strong></dt>
+    <dd>Will try and acquire the lock. The optional <code>timeout</code> can be
+    used to override the timeout value set when the lock was created.</br>
+    If the the lock is not available, the coroutine will yield until either the
+    lock becomes available, or it times out. The one exception is when
+    <code>timeout</code> is 0, then it will immediately return without yielding.</br>
+    Upon success, it will return the <code>wait-time</code> in seconds. Upon failure it will
+    return <code>nil + error + wait-time</code>. Upon a timeout the error value will
+    be "timeout".
+    </dd>
+
+    <dt><strong><code>lock.new([timeout], [not_reentrant])</code></strong></dt>
+    <dd>Creates and returns a new lock. The <code>timeout</code> specifies the
+    default timeout for the lock in
+    seconds, and defaults to 10. By default the lock is re-entrant,
+    except if <code>not_reentrant</code> is set to a truthy value.
+    </dd>
+
+    <dt><strong><code>lock:release()</code></strong></dt>
+    <dd>Releases the currently held lock. Returns <code>true</code> or <code>nil + error</code>.
+    </dd>
+
     <dt><strong><code>timer.new(options)</code></strong></dt>
     <dd>Creates and returns an (armed) timer object. The <code>options</code> table has the following fields;
     <ul>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -152,9 +152,9 @@ are used to register servers and to execute the main loop of Copas:</p>
         error, coroutine, and socket as arguments.
     </dd>
 
-    <dt><strong><code>copas.settimeout(delay, [callback])</code></strong></dt>
+    <dt><strong><code>copas.settimeout(delay, callback)</code></strong></dt>
     <dd>Creates a timeout timer for the current coroutine. The <code>delay</code>
-        is the timeout in seconds, and the optional <code>callback</code> will
+        is the timeout in seconds, and the <code>callback</code> will
         be called upon an actual timeout occuring.</br>
         Calling it repeatedly will simply replace the timeout on the current
         coroutine and any previous callback set will no longer be called.</br>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -88,6 +88,10 @@ are used to register servers and to execute the main loop of Copas:</p>
         truthy (neither <code>nil</code> nor <code>false</code>).
     </dd>
 
+    <dt><strong><code>copas.canceltimeout()</code></strong></dt>
+    <dd>Cancels the timeout for the current coroutine.
+    </dd>
+
     <dt><strong><code>copas.finished()</code></strong></dt>
     <dd>Checks whether anything remains to be done.<br />
         Returns <code>false</code> when the socket lists for reading and writing
@@ -146,6 +150,17 @@ are used to register servers and to execute the main loop of Copas:</p>
     <dd>Sets the error handling function for the current thread. Any
         errors will be forwarded to the handler, which will receive the
         error, coroutine, and socket as arguments.
+    </dd>
+
+    <dt><strong><code>copas.settimeout(delay, [callback])</code></strong></dt>
+    <dd>Creates a timeout timer for the current coroutine. The <code>delay</code>
+        is the timeout in seconds, and the optional <code>callback</code> will
+        be called upon an actual timeout occuring.</br>
+        Calling it repeatedly will simply replace the timeout on the current
+        coroutine and any previous callback set will no longer be called.</br>
+        <strong>NOTE:</strong> The timeouts are a low-level Copas feature, and
+        should only be used to wrap an explicit yield to the Copas scheduler. They
+        should not be used to wrap user code.
     </dd>
 </dl>
 

--- a/src/copas/lock.lua
+++ b/src/copas/lock.lua
@@ -1,0 +1,193 @@
+local copas = require("copas")
+local gettime = require("socket").gettime
+
+local DEFAULT_TIMEOUT = 10
+
+local lock = {}
+lock.__index = lock
+
+
+-- registry, locks indexed by the coroutines using them.
+local registry = setmetatable({}, { __mode="kv" })
+
+
+
+--- Creates a new lock.
+-- @param seconds (optional) default timeout in seconds when acquiring the lock (defaults to 10)
+-- @param not_reentrant (optional) if truthy the lock will not allow a coroutine to grab the same lock multiple times
+-- @return the lock object
+function lock.new(seconds, not_reentrant)
+  local timeout = tonumber(seconds or DEFAULT_TIMEOUT) or -1
+  if timeout < 0 then
+    error("expected timeout (1st argument) to be a number greater than or equal to 0, got: " .. tostring(seconds), 2)
+  end
+  return setmetatable({
+            timeout = timeout,
+            not_reentrant = not_reentrant,
+            queue = {},
+            q_tip = 0,  -- index of the first in line waiting
+            q_tail = 0, -- index where the next one will be inserted
+            owner = nil, -- coroutine holding lock currently
+            call_count = nil, -- recursion call count
+            errors = setmetatable({}, { __mode = "k" }), -- error indexed by coroutine
+          }, lock)
+end
+
+
+
+do
+  local destroyed_func = function()
+    return nil, "destroyed"
+  end
+
+  local destroyed_lock_mt = {
+    __index = function()
+      return destroyed_func
+    end
+  }
+
+  --- destroy a lock.
+  -- Releases all waiting threads with `nil+"destroyed"`
+  function lock:destroy()
+    --print("destroying ",self)
+    for i = self.q_tip, self.q_tail do
+      local co = self.queue[i]
+      if co then
+        self.errors[co] = "destroyed"
+        --print("marked destroyed ", co)
+        copas.wakeup(co)
+      end
+    end
+    if self.owner then
+      self.errors[self.owner] = "destroyed"
+      --print("marked destroyed ", co)
+    end
+    self.queue = {}
+    self.q_tip = 0
+    self.q_tail = 0
+    self.destroyed = true
+
+    setmetatable(self, destroyed_lock_mt)
+    return true
+  end
+end
+
+
+local function timeout_handler(co)
+  local self = registry[co]
+
+  for i = self.q_tip, self.q_tail do
+    if co == self.queue[i] then
+      self.queue[i] = nil
+      self.errors[co] = "timeout"
+      --print("marked timeout ", co)
+      copas.wakeup(co)
+      return
+    end
+  end
+  -- if we get here, we own it currently, or we finished it by now, or
+  -- the lock was destroyed. Anyway, nothing to do here...
+end
+
+
+--- Acquires the lock.
+-- If the lock is owned by another thread, this will yield control, until the
+-- lock becomes available, or it times out.
+-- If `timeout == 0` then it will immediately return (without yielding).
+-- @param timeout (optional) timeout in seconds, if given overrides the timeout passed to `new`.
+-- @return wait-time on success, or nil+error+wait_time on failure. Errors can be "timeout", "destroyed", or "lock is not re-entrant"
+function lock:get(timeout)
+  local co = coroutine.running()
+  local start_time
+
+  -- is the lock already taken?
+  if self.owner then
+    -- are we re-entering?
+    if co == self.owner then
+      if self.not_reentrant then
+        return nil, "lock is not re-entrant", 0
+      else
+        self.call_count = self.call_count + 1
+        return 0
+      end
+    end
+
+    self.queue[self.q_tail] = co
+    self.q_tail = self.q_tail + 1
+    timeout = timeout or self.timeout
+    if timeout == 0 then
+      return nil, "timeout", 0
+    end
+
+    -- set up timeout
+    registry[co] = self
+    copas.settimeout(timeout, timeout_handler)
+
+    start_time = gettime()
+    copas.sleep(-1)
+
+    local err = self.errors[co]
+    self.errors[co] = nil
+
+    --print("released ", co, err)
+    if err ~= "timeout" then
+      copas.canceltimeout()
+    end
+    if err then
+      self.errors[co] = nil
+      return nil, err, gettime() - start_time
+    end
+  end
+
+  -- it's ours to have
+  self.owner = co
+  self.call_count = 1
+  return start_time and (gettime() - start_time) or 0
+end
+
+
+--- Releases the lock currently held.
+-- Releasing a lock that is not owned by the current co-routine will return
+-- an error.
+-- returns true, or nil+err on an error
+function lock:release()
+  local co = coroutine.running()
+
+  if co ~= self.owner then
+    return nil, "cannot release a lock not owned"
+  end
+
+  self.call_count = self.call_count - 1
+  if self.call_count > 0 then
+    -- same coro is still holding it
+    return true
+  end
+
+  if self.q_tail == self.q_tip then
+    -- queue is empty
+    self.owner = nil
+    return true
+  end
+
+  -- need a loop, since an individual coroutine might have been removed
+  -- so there might be holes
+  while self.q_tip < self.q_tail do
+    local next_up = self.queue[self.q_tip]
+    if next_up then
+      self.owner = next_up
+      self.queue[self.q_tip] = nil
+      self.q_tip = self.q_tip + 1
+      copas.wakeup(next_up)
+      return true
+    end
+    self.q_tip = self.q_tip + 1
+  end
+  -- queue is empty, reset pointers
+  self.q_tip = 0
+  self.q_tail = 0
+  return true
+end
+
+
+
+return lock

--- a/tests/httpredirect.lua
+++ b/tests/httpredirect.lua
@@ -17,7 +17,7 @@ local function doreq(url)
   reqt.sink = ltn12.sink.table(reqt.target)
 
   local result, code, headers, status = http.request(reqt)
-  print(string.rep("=",70))
+  print(string.rep("-",70))
   print("Fetching:",url,"==>",code, status)
   if dump_all_headers then
     if headers then

--- a/tests/lock.lua
+++ b/tests/lock.lua
@@ -1,0 +1,99 @@
+-- make sure we are pointing to the local copas first
+package.path = string.format("../src/?.lua;%s", package.path)
+
+
+
+local copas = require "copas"
+local lock = require "copas.lock"
+local gettime = require("socket").gettime
+
+copas.loop(function()
+
+  local lock1 = lock.new(nil, true)  -- no re-entrant
+  assert(lock1:get())
+  local _, err = lock1:get()
+  assert(err == "lock is not re-entrant", "got errror: "..tostring(err))
+
+  -- let go and reacquire
+  assert(lock1:release())
+  local _, err = lock1:release()
+  assert(err == "cannot release a lock not owned", "got errror: "..tostring(err))
+
+  assert(lock1:get())
+  lock1:destroy()
+  local _, err = lock1:release()
+  assert(err == "destroyed", "got errror: "..tostring(err))
+
+
+  -- let's scale, go grab a lock
+  lock1 = assert(lock.new(10))
+  assert(lock1:get())
+
+  local success_count = 0
+  local timeout_count = 0
+  local destroyed_count = 0
+  -- now add another bunch of threads for the same lock
+  local size = 1500 -- must be multiple of 3 !!
+  print("creating "..size.." threads hitting the lock...", gettime())
+  local tracker = {}
+  for i = 1, size do
+    tracker[i] = true
+    copas.addthread(function()
+      local timeout
+      if i > (size*2)/3 then
+        timeout = 60    -- the ones to hit "destroyed"
+      elseif i > size/3 and i <= (size*2)/3 then
+        timeout = 2     -- the ones to hit "timeout"
+      else
+        timeout = 1     -- the ones to succeed
+      end
+      --print(i, "waiting...")
+      local ok, err = lock1:get(timeout)
+      if ok then
+        --print(i, "got it!")
+        success_count = success_count + 1
+        if i == size/3 then
+          copas.sleep(2) -- keep it long enough for the next 500 to timeout
+          --print(i, "releasing ")
+          assert(lock1:release()) -- by now the 2nd 500 timed out
+          --print(i, "destroying ")
+          assert(lock1:destroy()) -- make the last 500 fail on "destroyed"
+        else
+          --print(i, "releasing ")
+          assert(lock1:release())
+        end
+        tracker[i] = nil
+
+      elseif err == "timeout" then
+        --print(i, "timed out!")
+        timeout_count = timeout_count + 1
+        --if i == (size*2)/3 then
+        --  copas.sleep(2) -- to ensure thread 500 finished its sleep above
+        --end
+        tracker[i] = nil
+
+      elseif err == "destroyed" then
+        --print(i, "destroyed!")
+        destroyed_count = destroyed_count + 1
+        tracker[i] = nil
+
+      else
+        tracker[i] = nil
+        error("didn't expect error: '"..tostring(err).."' thread "..i)
+      end
+
+    end)  -- added thread function
+  end -- for loop
+  print("releasing "..size.." threads...", gettime())
+  assert(lock1:release())
+  print("waiting to finish...")
+  while next(tracker) do copas.sleep(0.1) end
+  -- check results
+  print("success: ", success_count)
+  print("timeout: ", timeout_count)
+  print("destroyed: ", destroyed_count)
+  assert(success_count == size/3)
+  assert(timeout_count == size/3)
+  assert(destroyed_count == size/3)
+end)
+print("test success!")


### PR DESCRIPTION
Adds a base timeout interface which can be implemented on the
sockets and other yielding elements.

Current implementation uses regular timers which are not efficient
but this decouples the timeout implementation from timer update
for now