### PR TITLE
fix(loop) do not exit early if potential work remains

### DIFF
--- a/copas-cvs-6.rockspec
+++ b/copas-cvs-6.rockspec
@@ -22,7 +22,7 @@ dependencies = {
    "luasocket >= 2.1",
    "coxpcall >= 1.14",
    "binaryheap >= 0.4",
-   "timerwheel >= 0.1",
+   "timerwheel >= 0.2",
 }
 build = {
    type = "builtin",

--- a/tests/lock.lua
+++ b/tests/lock.lua
@@ -7,6 +7,7 @@ local copas = require "copas"
 local lock = require "copas.lock"
 local gettime = require("socket").gettime
 
+local test_complete = false
 copas.loop(function()
 
   local lock1 = lock.new(nil, true)  -- no re-entrant
@@ -95,5 +96,9 @@ copas.loop(function()
   assert(success_count == size/3)
   assert(timeout_count == size/3)
   assert(destroyed_count == size/3)
+
+  test_complete = true
 end)
+assert(test_complete, "test did not complete!")
+
 print("test success!")


### PR DESCRIPTION
timeouts were not considered work (fallbacks), neither was the
lethargy ('unreachable' task parkinglot). But in case of a combination
then there might be work remaining. A timeout might wakeup a
lethargy task.