### PR TITLE
Support copas.sleep() in the main thread

### DIFF
--- a/src/copas.lua
+++ b/src/copas.lua
@@ -892,9 +892,16 @@ end
 -------------------------------------------------------------------------------
 
 -- yields the current coroutine and wakes it after 'sleeptime' seconds.
--- If sleeptime < 0 then it sleeps until explicitly woken up using 'wakeup'
+-- If sleeptime<0 then it sleeps until explicitly woken up using 'wakeup'
+-- If not in a coroutine context, the main thread just sleeps for the
+-- given amount of time.
 function copas.sleep(sleeptime)
-  coroutine.yield((sleeptime or 0), _sleeping)
+  local co, ismain = coroutine.running()
+  if (not co) or ismain then
+    socket.sleep(sleeptime)
+  else
+    coroutine.yield((sleeptime or 0), _sleeping)
+  end
 end
 
 -- Wakes up a sleeping coroutine 'co'.


### PR DESCRIPTION
Useful when writing functions that work both in and out of a copas context.