### PR TITLE
feat(tls-sni) add support for SNI in TLS handshake (alternative to #81)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test: certs
 	$(LUA) $(DELIM) $(PKGPATH) tests/sleep.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/tcptimeout.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/timer.lua
+	$(LUA) $(DELIM) $(PKGPATH) tests/tls-sni.lua
 	$(LUA) $(DELIM) $(PKGPATH) tests/udptimeout.lua
 	$(LUA) $(DELIM)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,7 @@ LuaSocket, <a href="http://keplerproject.github.io/coxpcall/">Coxpcall</a> (only
 <dl class="history">
     <dt><strong>Copas</strong> [unreleased]</dt>
 	<dd><ul>
+        <li>Added: support for SNI on TLS connections #81 (@amyspark)</li>
         <li>Fixed: closing sockets from another thread would make the read/write ops hang #104</li>
         <li>Fixed: coxpcall dependency in limit.lua #63 (Francois Perrad)</li>
         <li>Change: update deprecated tls default to tls 1.2 in (copas.http)</li>

--- a/tests/tls-sni.lua
+++ b/tests/tls-sni.lua
@@ -1,0 +1,102 @@
+-- Tests Copas with a simple Echo server
+--
+-- Run the test file and the connect to the server using telnet on the used port.
+-- The server should be able to echo any input, to stop the test just send the command "quit"
+
+local port = 20000
+local copas = require("copas")
+local socket = require("socket")
+local ssl = require("ssl")
+local server
+
+local server_params = {
+  wrap = {
+    mode = "server",
+    protocol = "tlsv1",
+    key = "tests/certs/serverAkey.pem",
+    certificate = "tests/certs/serverA.pem",
+    cafile = "tests/certs/rootA.pem",
+    verify = {"peer", "fail_if_no_peer_cert"},
+    options = {"all", "no_sslv2"},
+  },
+  sni = {
+    strict = true, -- only allow connection 'myhost.com'
+    names = {}
+  }
+}
+server_params.sni.names["myhost.com"] = ssl.newcontext(server_params.wrap)
+
+local client_params = {
+  wrap = {
+    mode = "client",
+    protocol = "tlsv1",
+    key = "tests/certs/clientAkey.pem",
+    certificate = "tests/certs/clientA.pem",
+    cafile = "tests/certs/rootA.pem",
+    verify = {"peer", "fail_if_no_peer_cert"},
+    options = {"all", "no_sslv2"},
+  },
+  sni = {
+    names = "" -- will be added in test below
+  }
+}
+
+local function echoHandler(skt)
+  while true do
+    local data, err = skt:receive()
+    if not data then
+      if err ~= "closed" then
+        return error("client connection error: "..tostring(err))
+      else
+        return -- client closed the connection
+      end
+
+    elseif data == "quit" then
+      return -- close this client connection
+
+    elseif data == "exit" then
+      copas.removeserver(server)
+      return -- close this client connection, after stopping the server
+
+    end
+    skt:send(data)
+  end
+end
+
+server = assert(socket.bind("*", port))
+copas.addserver(server, copas.handler(echoHandler, server_params))
+
+copas.addthread(function()
+  copas.sleep(0.5) -- allow server socket to be ready
+
+  ----------------------
+  -- Tests start here --
+  ----------------------
+
+  -- try with a bad SNI (non matching)
+  client_params.sni.names = "badhost.com"
+  local skt = copas.wrap(socket.tcp(), client_params)
+  local _, err = pcall(skt.connect, skt, "localhost", port)
+  if not tostring(err):match("TLS/SSL handshake failed:") then
+    print "expected handshake to fail"
+    os.exit(1)
+  end
+
+
+  -- try again with a proper SNI (matching)
+  client_params.sni.names = "myhost.com"
+  local skt = copas.wrap(socket.tcp(), client_params)
+  local success, ok = pcall(skt.connect, skt, "localhost", port)
+  if not (success and ok) then
+    print "expected connection to be completed"
+    os.exit(1)
+  end
+
+  print "succesfully completed test"
+  os.exit(0)
+end)
+
+-- no ugly errors please, comment out when debugging
+copas.setErrorHandler(function() end, true)
+
+copas.loop()


### PR DESCRIPTION
alternative implementation for #81 

Previously the `sslparams` arguments provided to either `socket.connect`, or to `copas.handler`, would simply be the single parameter (a table or a context) to the underlying LuaSec `ssl.wrap` method. And Copas would execute both the `ssl.wrap` and `conn:dohandshake` right after each other.

With the addition of SNI, there are now more calls to be made between wrapping the socket in the ssl one, and actually doing the handshake.

The ssl parameter use in Copas has been split in two.

- functions mimicking the original api's `copas.dohandshake`, and the new `socket:sni`, take the original parameters. Same as the LuaSec based parameters.
- Copas specific functions `copas.wrap` and `copas.handler` now take a new table format (but is backward compatible)

The new table format has entries for each LuaSec function to be called, a full table would look like this:
```lua
local ssl_params = {
  wrap = {
    mode = "client",
    protocol = "any",
  },
  sni = {
    names = "host.com",
    strict = nil,
  }
}
```
This format allows for future extensions not yet implemented, like `conn:setdane`, or `conn:settlsa` for example.

The above table is used in `copas.wrap` then calling `sock:connect(...)` on the wrapped socket, will automatically call `sni` and `dohandshake` after the connection is established. So when the call returns, the socket has been secured.

Similar for server sockets;
```lua
local skt = socket.tcp():bind(...)
copas.addserver(skt, copas.handler(function(skt)
    -- in this handler, the `skt` has already been wrapped, and the sni/handshake performed successfully

    -- handle incoming connection here

  end, ssl_params))
```

closes #81 
fixes #77